### PR TITLE
Add liberime-load-on-require to defer the load-time engine start

### DIFF
--- a/README.org
+++ b/README.org
@@ -120,6 +120,21 @@ https://gist.github.com/merrickluo/553f39c131d0eb717cd59f72c9d4b60d
   (require 'liberime nil t))
 #+END_SRC
 
+*** 延迟启动（第三方 require 场景）
+默认情况下，加载 liberime 会在文件末尾自动调用 ~(liberime-load)~ ，即在
+=require= 时就启动 rime 引擎，并读取 ~liberime-user-data-dir~ 、
+~liberime-module-file~ 等变量。如果 =require= 是由第三方包（如 pyim）发起的，
+你就无法用上面的 =let= 把它包裹起来以在加载前设置这些变量。此时可将
+~liberime-load-on-require~ 设为 nil，之后自行调用 ~liberime-load~ ：
+#+BEGIN_SRC emacs-lisp
+(setq liberime-load-on-require nil)   ; 需在 liberime 加载前设置
+(with-eval-after-load 'liberime
+  (setq liberime-user-data-dir "/PATH/TO/YOUR/rime")
+  (liberime-load))
+#+END_SRC
+
+如需静默启动时的提示信息，可设置 ~(setq liberime-verbose nil)~ 。
+
 ** 部署 Rime
 
 手动修改 librime 配置后，可以调用 ~(liberime-deploy)~ 重新部署。

--- a/liberime.el
+++ b/liberime.el
@@ -56,6 +56,16 @@ More info: https://github.com/rime/home/wiki/SharedData"
   :group 'liberime
   :type 'boolean)
 
+(defcustom liberime-load-on-require t
+  "If non-nil, load the module and start rime when this file is loaded.
+When nil, loading `liberime' only defines things; you then call
+`liberime-load' yourself after setting `liberime-user-data-dir',
+`liberime-module-file' and friends.  This helps when a third-party
+package (e.g. pyim) issues the `require', so you cannot wrap it in a
+`let' to bind those variables around load time."
+  :group 'liberime
+  :type 'boolean)
+
 (defvar liberime-select-schema-timer nil
   "Timer used by `liberime-select-schema'.")
 
@@ -300,7 +310,8 @@ if NAMES is nil, \"rime-data\" as fallback."
           (goto-char (point-min)))
         (pop-to-buffer buf)))))
 
-(liberime-load)
+(when liberime-load-on-require
+  (liberime-load))
 
 (defun liberime-get-preedit ()
   "Get rime preedit."

--- a/liberime.el
+++ b/liberime.el
@@ -66,6 +66,11 @@ package (e.g. pyim) issues the `require', so you cannot wrap it in a
   :group 'liberime
   :type 'boolean)
 
+(defcustom liberime-verbose t
+  "If non-nil, echo progress messages while starting rime."
+  :group 'liberime
+  :type 'boolean)
+
 (defvar liberime-select-schema-timer nil
   "Timer used by `liberime-select-schema'.")
 
@@ -277,9 +282,9 @@ if NAMES is nil, \"rime-data\" as fallback."
   (let ((shared-dir (liberime-get-shared-data-dir))
         (user-dir (liberime-get-user-data-dir)))
     (when (and shared-dir user-dir)
-      (message "Liberime: start with shared dir: %S" shared-dir)
-      (message "Liberime: start with user dir: %S" user-dir)
-      (message "")
+      (when liberime-verbose
+        (message "Liberime: start with shared dir: %S" shared-dir)
+        (message "Liberime: start with user dir: %S" user-dir))
       (liberime-start shared-dir user-dir)
       (when liberime-current-schema
         (liberime-try-select-schema liberime-current-schema))


### PR DESCRIPTION
## Problem

`liberime.el` ends with a top-level `(liberime-load)`, so merely *loading*
the library performs side effects before any user configuration can run:

- it loads (or auto-builds) the native module, reading `liberime-module-file`
  and `liberime-auto-build`;
- it calls `liberime--start`, which reads `liberime-user-data-dir` /
  `liberime-shared-data-dir` and starts the Rime engine;
- it prints three `message` lines to the echo area.

The README's supported way to configure this is to bind the vars in a `let`
around the `require`:

```elisp
(let ((liberime-auto-build t)) (require 'liberime nil t))
```

That idiom is **unreachable when a third party issues the `require`** — e.g.
pyim, or Doom Emacs' `:input chinese` module, calls `(require 'liberime)` for
you, so you cannot wrap it in a `let`. Users are forced to advise
`liberime-load` to sneak their settings in before the load-time start. (The
project's own CI hits the same wall — `test.yml` has to `(provide
'liberime-core)` *before* loading the file precisely because the top-level
`(liberime-load)` runs at load time.)

## Change

1. **`liberime-load-on-require`** (defcustom, default `t` — no behavior change).
   Gates the top-level start:

   ```elisp
   (when liberime-load-on-require
     (liberime-load))
   ```

   Set it to `nil` to defer, then call `(liberime-load)` yourself after setting
   the variables — the standard Emacs idiom that works regardless of who
   requires the library:

   ```elisp
   (setq liberime-load-on-require nil)      ; before liberime loads
   (with-eval-after-load 'liberime
     (setq liberime-user-data-dir "…"
           liberime-module-file  "…")
     (liberime-load))
   ```

2. **`liberime-verbose`** (defcustom, default `t` — no behavior change). Guards
   the two start-up dir messages and drops the stray `(message "")`, so a
   load-time start no longer spams the echo area. `(setq liberime-verbose nil)`
   silences it without `inhibit-message` tricks.

3. README: a short `延迟启动` subsection documenting the deferred-start idiom.

## Backward compatibility & testing

Defaults are unchanged, so existing `(require 'liberime)` users see no
difference. Byte-compiles clean under the CI command
(`byte-compile-error-on-warn t`). Verified by loading the file in batch under
each setting:

| `liberime-load-on-require` | engine started at `require`? | start messages |
|---|---|---|
| `t` (default) | yes | 2 (or 0 with `liberime-verbose nil`) |
| `nil` | **no** | 0 |
