### PR TITLE
Add optional SCHEMA_ID arg to liberime-search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ Debug
 /*.zip
 /Makefile-liberime-build
 test/test_liberime
+src/liberime-core.dylib
+liberime-core.dylib

--- a/liberime-test.el
+++ b/liberime-test.el
@@ -11,7 +11,7 @@
 
 (liberime-get-schema-list)
 (liberime-select-schema "luna_pinyin_simp")
-(liberime-search "wode" nil)
+(liberime-search "wode" nil nil "luna_pinyin_simp")
 (liberime-finalize)
 (liberime-get-user-config "default.custom" "patch/menu/page_size" "int")
 (liberime-set-user-config "default.custom" "patch/menu/page_size" 100 "int")

--- a/src/liberime-core.c
+++ b/src/liberime-core.c
@@ -220,10 +220,13 @@ static emacs_value _build_candidate_list(emacs_env *env,
 }
 
 DOCSTRING(
-    search, "STRING &optional LIMIT INDEX",
+    search, "STRING &optional LIMIT INDEX SCHEMA_ID",
     "Input STRING and return LIMIT number candidates starting from INDEX.\n"
     "When LIMIT is nil, return all candidates from INDEX.\n"
     "When INDEX is nil, start from 0.\n"
+    "SCHEMA_ID, when non-nil, searches using the given schema.\n"
+    "It only affects the temporary session, so the schema of the\n"
+    "default session and global state are unchanged.\n"
     "This function always uses a separate session to avoid\n"
     "interfering with current input.");
 static emacs_value search(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
@@ -246,6 +249,11 @@ static emacs_value search(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
     index = env->extract_integer(env, args[2]);
   }
 
+  char *schema_id = NULL;
+  if (nargs >= 4 && env->is_not_nil(env, args[3])) {
+    schema_id = em_get_string(env, args[3]);
+  }
+
   // Always create a new session for search to avoid interfering with
   // the default session
   RimeSessionId session_id = rime->api->create_session();
@@ -253,7 +261,32 @@ static emacs_value search(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
   if (!session_id) {
     em_signal_rimeerr(env, 1, "Cannot create session.");
     free(string);
+    free(schema_id);
     return em_nil;
+  }
+
+  if (schema_id) {
+    // Select schema for the temporary session only, so the default
+    // session and global state are not affected.
+    bool schema_found = false;
+    RimeSchemaList schema_list;
+    if (rime->api->get_schema_list(&schema_list)) {
+      for (int i = 0; i < schema_list.size; i++) {
+        if (strcmp(schema_list.list[i].schema_id, schema_id) == 0) {
+          schema_found = true;
+          break;
+        }
+      }
+      rime->api->free_schema_list(&schema_list);
+    }
+    if (!schema_found || !rime->api->select_schema(session_id, schema_id)) {
+      free(schema_id);
+      free(string);
+      rime->api->destroy_session(session_id);
+      em_signal_rimeerr(env, 1, "Failed to select schema.");
+      return em_nil;
+    }
+    free(schema_id);
   }
 
   rime->api->clear_composition(session_id);
@@ -1132,7 +1165,7 @@ void liberime_init(emacs_env *env) {
   }
 
   DEFUN("liberime-start", start, 2, 2);
-  DEFUN("liberime-search", search, 1, 3);
+  DEFUN("liberime-search", search, 1, 4);
   DEFUN("liberime-get-candidates", get_candidates, 0, 2);
   DEFUN("liberime-select-schema", select_schema, 1, 1);
   DEFUN("liberime-get-schema-list", get_schema_list, 0, 0);

--- a/test/liberime-test.el
+++ b/test/liberime-test.el
@@ -101,6 +101,30 @@ Creates a temporary user data directory."
       (should (stringp (car schema)))
       (should (stringp (cadr schema))))))
 
+(ert-deftest liberime-test-search-with-schema ()
+  "liberime-search with SCHEMA_ID uses that schema in a temporary
+session without changing the schema of the default session."
+  (liberime-test--skip-unless-rime)
+  (let* ((schemas (liberime-get-schema-list))
+         (ids (mapcar #'car schemas)))
+    (when (>= (length ids) 2)
+      (let* ((current (liberime-get-schema-config "" "schema/schema_id"))
+             (target (if (string= current (nth 0 ids))
+                         (nth 1 ids)
+                       (nth 0 ids)))
+             (result (liberime-search "wode" nil nil target)))
+        ;; Search with explicit schema returns candidates
+        (should (listp result))
+        ;; Default session schema is unchanged
+        (should (string= current
+                         (liberime-get-schema-config ""
+                                                     "schema/schema_id")))))))
+
+(ert-deftest liberime-test-search-with-invalid-schema ()
+  "liberime-search with unknown SCHEMA_ID should signal an error."
+  (liberime-test--skip-unless-rime)
+  (should-error (liberime-search "wode" nil nil "no_such_schema_xyz")))
+
 ;; ---------------------------------------------------------------------------
 ;; Input processing tests
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Allow searching with a specific rime schema via a new optional SCHEMA_ID argument. The schema is selected on the temporary session only (librime select_schema is per-session), so the default session and global state are unaffected. Invalid schema ids signal an error instead of silently falling back to the default schema.