### PR TITLE
feat(search): FULL-CONTEXT query, trace-free schema, multi-session SESSION argument

### DIFF
--- a/README.org
+++ b/README.org
@@ -176,3 +176,34 @@ Rime 同步功能的其它信息可以参考：[[https://github.com/rime/home/wi
 ~ni~）、~:remainder~ = ~"haoshijie"~。这些数据让 liberime-regexp 之类的
 调用方可以把 Rime 码递归展开为正则表达式。向后兼容：不传该参数时行为与
 旧版一致（返回候选文本列表）。
+
+** 多 session 与 SESSION 参数
+
+librime 原生支持多个相互独立的 session（各自持有 composition、候选和
+schema）。liberime 现将其暴露给 Elisp：
+
+- ~(liberime-session-create &optional SCHEMA_ID)~ —— 创建临时 session，返
+  回其 id；指定 ~SCHEMA_ID~ 时该 session 使用此 schema（对 user config 无
+  任何持久化痕迹）。librime 会在 5 分钟不活动后自动回收闲置 session，
+~liberime-finalize~ 也会清空全部 session。
+- ~(liberime-session-destroy SESSION)~ —— 销毁临时 session。
+
+以下函数接受尾部可选参数 ~SESSION~（~nil~ 表示默认 session，行为与旧版
+一致）：~liberime-search~（~SESSION~ 非 ~nil~ 时复用该 session 查询，不再
+创建/销毁临时 session）、~liberime-process-key~、~liberime-simulate-key-sequence~、
+~liberime-process-event~、~liberime-get-context~、~liberime-get-status~、
+~liberime-get-commit~、~liberime-get-input~、~liberime-clear-composition~、
+~liberime-commit-composition~、~liberime-select-candidate~、
+~liberime-get-candidates~。
+
+例如，一个 session 内连续查询多个码（避免反复创建/销毁临时 session 的开
+销），或让两个 session 使用不同 schema 互不干扰：
+
+#+begin_src emacs-lisp
+  (let ((s1 (liberime-session-create "egret_py"))
+        (s2 (liberime-session-create "luna_pinyin_simp")))
+    (liberime-search "ni" nil nil nil t s1)
+    (liberime-search "ni" nil nil nil t s2)
+    (liberime-session-destroy s1)
+    (liberime-session-destroy s2))
+#+end_src

--- a/README.org
+++ b/README.org
@@ -150,3 +150,29 @@ https://gist.github.com/merrickluo/553f39c131d0eb717cd59f72c9d4b60d
    #+end_src
 
 Rime 同步功能的其它信息可以参考：[[https://github.com/rime/home/wiki/UserGuide#%E5%90%8C%E6%AD%A5%E7%94%A8%E6%88%B6%E8%B3%87%E6%96%99][Rime 同步用户资料]]。
+
+** liberime-search 的 FULL-CONTEXT 参数
+
+~liberime-search~ 的第 5 个可选参数 ~FULL-CONTEXT~ 让调用方获得 Rime 候选
+对输入码的消费结构，而不只是候选文本列表。传非 ~nil~ 时返回 plist：
+
+- ~:commit~ —— Rime 自动上屏的文本。形码等定长码 schema 在码超长时会顶出
+  已完成的字，该字不再出现在候选菜单中；无自动上屏时为 ~nil~。
+- ~:full~ —— 完整消耗输入码的候选（整词）。
+- ~:prefix~ —— 只消耗输入码最短非空前缀的候选（如拼音输入 ~nihaoshijie~
+  时，单字候选 ~你~ 只消耗 ~ni~）。
+- ~:remainder~ —— ~:prefix~ 消耗后剩下的码后缀（如 ~haoshijie~），可递归
+  展开。
+- ~:remaining-input~ —— 本次输入的原始码串（~get_input~ 的返回值），不依
+  附于任何前缀候选；用于判断 ~:commit~ 是否可信：提交后仍有未消费输入且
+  无候选时，~:commit~ 只是自动上屏的前缀，不能作为完整展开。
+- ~:schema-id~ / ~:schema-name~ —— 临时 session 实际使用的 schema（及
+  ~:is-disabled~、~:is-composing~、~:is-ascii-mode~、~:is-full-shape~、
+  ~:is-simplified~、~:is-traditional~、~:is-ascii-punct~ 等选项状态），让
+  调用方可以按产生候选的实际状态做缓存 key。
+
+例如拼音 schema 下 ~(liberime-search "nihaoshijie" nil nil nil t)~ 可能返
+回 ~:full~ = ~("你好世界")~、~:prefix~ = 单字候选（~你~ 等，只消耗
+~ni~）、~:remainder~ = ~"haoshijie"~。这些数据让 liberime-regexp 之类的
+调用方可以把 Rime 码递归展开为正则表达式。向后兼容：不传该参数时行为与
+旧版一致（返回候选文本列表）。

--- a/liberime-test.el
+++ b/liberime-test.el
@@ -11,7 +11,7 @@
 
 (liberime-get-schema-list)
 (liberime-select-schema "luna_pinyin_simp")
-(liberime-search "wode" nil nil "luna_pinyin_simp")
+(liberime-search "wode" nil nil "luna_pinyin_simp" t)
 (liberime-finalize)
 (liberime-get-user-config "default.custom" "patch/menu/page_size" "int")
 (liberime-set-user-config "default.custom" "patch/menu/page_size" 100 "int")

--- a/src/liberime-core.c
+++ b/src/liberime-core.c
@@ -103,6 +103,32 @@ static bool _ensure_session(EmacsRime *rime) {
   return true;
 }
 
+// Resolve an optional SESSION argument.  When SESSION_ARG is nil, the
+// default session is used (creating it if necessary); otherwise the given
+// session id must refer to a live session created by
+// `liberime-session-create'.  On failure (*ok == false) an error has been
+// signalled and the caller should return em_nil after releasing its own
+// resources.
+static RimeSessionId _resolve_session(emacs_env *env, EmacsRime *rime,
+                                      emacs_value session_arg, bool *ok) {
+  *ok = false;
+  if (env->is_not_nil(env, session_arg)) {
+    RimeSessionId id = (RimeSessionId)env->extract_integer(env, session_arg);
+    if (!rime->api->find_session(id)) {
+      em_signal_rimeerr(env, 1, NO_SESSION_ERR);
+      return 0;
+    }
+    *ok = true;
+    return id;
+  }
+  if (_ensure_session(rime)) {
+    *ok = true;
+    return rime->session_id;
+  }
+  em_signal_rimeerr(env, 1, NO_SESSION_ERR);
+  return 0;
+}
+
 static char *_copy_string(const char *str) {
   if (str) {
     size_t size = strnlen(str, CANDIDATE_MAXSTRLEN);
@@ -434,7 +460,7 @@ static void _plist_push(emacs_env *env, emacs_value plist[], int *pi,
 }
 
 DOCSTRING(
-    search, "STRING &optional LIMIT INDEX SCHEMA_ID FULL-CONTEXT",
+    search, "STRING &optional LIMIT INDEX SCHEMA_ID FULL-CONTEXT SESSION",
     "Input STRING and return LIMIT number candidates starting from INDEX.\n"
     "When LIMIT is nil, return all candidates from INDEX.\n"
     "When INDEX is nil, start from 0.\n"
@@ -478,7 +504,10 @@ DOCSTRING(
     "could be a whole-phrase candidate while :prefix contains single-\n"
     "character candidates that consume only \"ni\", with :remainder\n"
     "\"haoshijie\".  LIMIT still bounds how many highlighted states are\n"
-    "examined.");
+    "examined.\n"
+    "SESSION, when non-nil, is a session id from `liberime-session-create'\n"
+    "to search in; the session is reused instead of creating and destroying\n"
+    "a temporary one.");
 static emacs_value search(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
                           void *data) {
   EmacsRime *rime = (EmacsRime *)data;
@@ -509,21 +538,37 @@ static emacs_value search(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
     full_context = true;
   }
 
-  // Always create a new session for search to avoid interfering with
-  // the default session
-  RimeSessionId session_id = rime->api->create_session();
-
-  if (!session_id) {
-    em_signal_rimeerr(env, 1, "Cannot create session.");
-    free(string);
-    free(schema_id);
-    return em_nil;
+  // When SESSION is given, reuse that session instead of creating and
+  // destroying a temporary one.  The caller owns its lifetime.
+  bool reuse_session = false;
+  RimeSessionId session_id = 0;
+  if (nargs >= 6 && env->is_not_nil(env, args[5])) {
+    session_id = (RimeSessionId)env->extract_integer(env, args[5]);
+    if (!rime->api->find_session(session_id)) {
+      em_signal_rimeerr(env, 1, NO_SESSION_ERR);
+      free(string);
+      free(schema_id);
+      return em_nil;
+    }
+    reuse_session = true;
+  } else {
+    // Always create a new session for search to avoid interfering with
+    // the default session
+    session_id = rime->api->create_session();
+    if (!session_id) {
+      em_signal_rimeerr(env, 1, "Cannot create session.");
+      free(string);
+      free(schema_id);
+      return em_nil;
+    }
   }
 
   if (schema_id && !_select_temporary_schema(rime, session_id, schema_id)) {
     free(schema_id);
     free(string);
-    rime->api->destroy_session(session_id);
+    if (!reuse_session) {
+      rime->api->destroy_session(session_id);
+    }
     em_signal_rimeerr(env, 1, "Failed to select schema.");
     return em_nil;
   }
@@ -614,31 +659,85 @@ static emacs_value search(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
     free(expansions.remainder);
     _free_session_status(&status);
   } else {
-    EmacsRimeCandidates candidates =
-        _get_candidates(rime, session_id, index, limit);
+    EmacsRimeCandidates candidates = _get_candidates(rime, session_id, index, limit);
     result = _build_candidate_list(env, candidates);
     free_candidate_list(candidates.list);
   }
 
   free(string);
 
-  // Destroy the temporary session
-  rime->api->destroy_session(session_id);
+  if (!reuse_session) {
+    // Destroy the temporary session
+    rime->api->destroy_session(session_id);
+  }
 
   return result;
 }
+DOCSTRING(session_create, "&optional SCHEMA_ID",
+          "Create a new temporary rime session and return its id.\n"
+          "The session is independent of the default session and can be\n"
+          "used with any liberime function that accepts a SESSION argument.\n"
+          "Destroy it with `liberime-session-destroy'; stale sessions are\n"
+          "also recycled by librime after five minutes of inactivity.\n"
+          "SCHEMA_ID, when non-nil, selects that schema for the session\n"
+          "without leaving any trace in the user config.");
+static emacs_value session_create(emacs_env *env, ptrdiff_t nargs,
+                                  emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
+
+  char *schema_id = NULL;
+  if (nargs >= 1 && env->is_not_nil(env, args[0])) {
+    schema_id = em_get_string(env, args[0]);
+  }
+
+  RimeSessionId session_id = rime->api->create_session();
+  if (!session_id) {
+    em_signal_rimeerr(env, 1, "Cannot create session.");
+    free(schema_id);
+    return em_nil;
+  }
+
+  if (schema_id && !_select_temporary_schema(rime, session_id, schema_id)) {
+    free(schema_id);
+    rime->api->destroy_session(session_id);
+    em_signal_rimeerr(env, 1, "Failed to select schema.");
+    return em_nil;
+  }
+  free(schema_id);
+
+  return env->make_integer(env, (intmax_t)session_id);
+}
+
+DOCSTRING(session_destroy, "SESSION",
+          "Destroy a session created by `liberime-session-create'.");
+static emacs_value session_destroy(emacs_env *env, ptrdiff_t nargs,
+                                   emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
+
+  RimeSessionId session_id = (RimeSessionId)env->extract_integer(env, args[0]);
+  if (rime->api->destroy_session(session_id)) {
+    return em_t;
+  }
+  return em_nil;
+}
+
 
 DOCSTRING(
-    get_candidates, "&optional LIMIT INDEX",
-    "Get current candidates from the default session.\n"
+    get_candidates, "&optional LIMIT INDEX SESSION",
+    "Get current candidates from a rime session.\n"
     "LIMIT is max candidates to return, default all.\n"
     "INDEX is the starting position (0-based), default 0.\n"
-    "Unlike search, this does NOT clear composition or simulate key sequence.");
+    "SESSION is a session id from `liberime-session-create'; nil uses the\n"
+    "default session.  Unlike search, this does NOT clear composition or\n"
+    "simulate key sequence.");
 static emacs_value get_candidates(emacs_env *env, ptrdiff_t nargs,
                                   emacs_value args[], void *data) {
   EmacsRime *rime = (EmacsRime *)data;
-  if (!_ensure_session(rime)) {
-    em_signal_rimeerr(env, 1, NO_SESSION_ERR);
+
+  bool session_ok;
+  RimeSessionId session_id = _resolve_session(
+      env, rime, nargs >= 3 ? args[2] : em_nil, &session_ok);
+  if (!session_ok) {
     return em_nil;
   }
 
@@ -655,8 +754,7 @@ static emacs_value get_candidates(emacs_env *env, ptrdiff_t nargs,
     index = env->extract_integer(env, args[1]);
   }
 
-  EmacsRimeCandidates candidates =
-      _get_candidates(rime, rime->session_id, index, limit);
+  EmacsRimeCandidates candidates = _get_candidates(rime, session_id, index, limit);
 
   emacs_value result = _build_candidate_list(env, candidates);
   free_candidate_list(candidates.list);
@@ -770,31 +868,35 @@ static emacs_value select_schema(emacs_env *env, ptrdiff_t nargs,
 }
 
 // input
-DOCSTRING(process_key, "KEYCODE &optional MASK",
-          "Send KEYCODE to rime session and process it.");
+DOCSTRING(process_key, "KEYCODE &optional MASK SESSION",
+          "Send KEYCODE to rime session and process it.\n"
+          "SESSION is a session id from `liberime-session-create'; nil\n"
+          "uses the default session.");
 static emacs_value process_key(emacs_env *env, ptrdiff_t nargs,
                                emacs_value args[], void *data) {
   EmacsRime *rime = (EmacsRime *)data;
 
   int keycode = env->extract_integer(env, args[0]);
   int mask = 0;
-  if (nargs == 2) {
+  if (nargs >= 2 && env->is_not_nil(env, args[1])) {
     mask = env->extract_integer(env, args[1]);
   }
 
-  if (!_ensure_session(rime)) {
-    em_signal_rimeerr(env, 1, NO_SESSION_ERR);
+  bool session_ok;
+  RimeSessionId session_id =
+      _resolve_session(env, rime, nargs >= 3 ? args[2] : em_nil, &session_ok);
+  if (!session_ok) {
     return em_nil;
   }
 
-  if (rime->api->process_key(rime->session_id, keycode, mask)) {
+  if (rime->api->process_key(session_id, keycode, mask)) {
     return em_t;
   }
   return em_nil;
 }
 
 DOCSTRING(
-    simulate_key_sequence, "STRING",
+    simulate_key_sequence, "STRING &optional SESSION",
     "Simulate a key sequence STRING to rime session.\n"
     "STRING follows librime's KeySequence format:\n"
     "  - Plain ASCII chars (except '{', '}'): e.g. \"a\", \"1\", \" \"\n"
@@ -809,13 +911,15 @@ static emacs_value simulate_key_sequence(emacs_env *env, ptrdiff_t nargs,
   EmacsRime *rime = (EmacsRime *)data;
   char *string = em_get_string(env, args[0]);
 
-  if (!_ensure_session(rime)) {
-    em_signal_rimeerr(env, 1, NO_SESSION_ERR);
+  bool session_ok;
+  RimeSessionId session_id =
+      _resolve_session(env, rime, nargs >= 2 ? args[1] : em_nil, &session_ok);
+  if (!session_ok) {
     free(string);
     return em_nil;
   }
 
-  rime->api->simulate_key_sequence(rime->session_id, string);
+  rime->api->simulate_key_sequence(session_id, string);
   free(string);
   return em_t;
 }
@@ -879,7 +983,7 @@ static emacs_value liberime_event_to_key_sequence(emacs_env *env,
   return result;
 }
 
-DOCSTRING(liberime_process_event, "EVENT",
+DOCSTRING(liberime_process_event, "EVENT &optional SESSION",
           "Process Emacs EVENT by converting to key sequence and sending to "
           "librime.\n"
           "EVENT can be an integer (character with optional modifiers) or a "
@@ -888,32 +992,37 @@ static emacs_value liberime_process_event(emacs_env *env, ptrdiff_t nargs,
                                           emacs_value args[], void *data) {
   EmacsRime *rime = (EmacsRime *)data;
 
-  if (!_ensure_session(rime)) {
-    em_signal_rimeerr(env, 1, NO_SESSION_ERR);
-    return em_nil;
-  }
-
   char *key_seq = _event_to_key_sequence(env, args[0]);
   if (!key_seq) {
     return em_nil;
   }
 
-  bool success = rime->api->simulate_key_sequence(rime->session_id, key_seq);
+  bool session_ok;
+  RimeSessionId session_id =
+      _resolve_session(env, rime, nargs >= 2 ? args[1] : em_nil, &session_ok);
+  if (!session_ok) {
+    free(key_seq);
+    return em_nil;
+  }
+
+  bool success = rime->api->simulate_key_sequence(session_id, key_seq);
   free(key_seq);
   return success ? em_t : em_nil;
 }
 
-DOCSTRING(get_input, "", "Get rime input.");
+DOCSTRING(get_input, "&optional SESSION", "Get rime input.");
 static emacs_value get_input(emacs_env *env, ptrdiff_t nargs,
                              emacs_value args[], void *data) {
   EmacsRime *rime = (EmacsRime *)data;
 
-  if (!_ensure_session(rime)) {
-    em_signal_rimeerr(env, 1, NO_SESSION_ERR);
+  bool session_ok;
+  RimeSessionId session_id =
+      _resolve_session(env, rime, nargs >= 1 ? args[0] : em_nil, &session_ok);
+  if (!session_ok) {
     return em_nil;
   }
 
-  const char *input = rime->api->get_input(rime->session_id);
+  const char *input = rime->api->get_input(session_id);
 
   if (!input) {
     return em_nil;
@@ -922,44 +1031,57 @@ static emacs_value get_input(emacs_env *env, ptrdiff_t nargs,
   }
 }
 
-DOCSTRING(commit_composition, "", "Commit rime composition.");
+DOCSTRING(commit_composition, "&optional SESSION",
+          "Commit rime composition.");
 static emacs_value commit_composition(emacs_env *env, ptrdiff_t nargs,
                                       emacs_value args[], void *data) {
   EmacsRime *rime = (EmacsRime *)data;
 
-  if (!_ensure_session(rime)) {
-    em_signal_rimeerr(env, 1, NO_SESSION_ERR);
+  bool session_ok;
+  RimeSessionId session_id =
+      _resolve_session(env, rime, nargs >= 1 ? args[0] : em_nil, &session_ok);
+  if (!session_ok) {
     return em_nil;
   }
 
-  if (rime->api->commit_composition(rime->session_id)) {
+  if (rime->api->commit_composition(session_id)) {
     return em_t;
   }
   return em_nil;
 }
 
-DOCSTRING(clear_composition, "", "Clear rime composition.");
+DOCSTRING(clear_composition, "&optional SESSION", "Clear rime composition.");
 static emacs_value clear_composition(emacs_env *env, ptrdiff_t nargs,
                                      emacs_value args[], void *data) {
   EmacsRime *rime = (EmacsRime *)data;
 
-  if (!_ensure_session(rime)) {
-    em_signal_rimeerr(env, 1, NO_SESSION_ERR);
+  bool session_ok;
+  RimeSessionId session_id =
+      _resolve_session(env, rime, nargs >= 1 ? args[0] : em_nil, &session_ok);
+  if (!session_ok) {
     return em_nil;
   }
 
-  rime->api->clear_composition(rime->session_id);
+  rime->api->clear_composition(session_id);
   return em_t;
 }
 
-DOCSTRING(select_candidate, "NUM", "Select a rime candidate by NUM.");
+DOCSTRING(select_candidate, "NUM &optional SESSION",
+          "Select a rime candidate by NUM.");
 static emacs_value select_candidate(emacs_env *env, ptrdiff_t nargs,
                                     emacs_value args[], void *data) {
   EmacsRime *rime = (EmacsRime *)data;
 
   int index = env->extract_integer(env, args[0]);
 
-  if (rime->api->select_candidate_on_current_page(rime->session_id, index)) {
+  bool session_ok;
+  RimeSessionId session_id =
+      _resolve_session(env, rime, nargs >= 2 ? args[1] : em_nil, &session_ok);
+  if (!session_ok) {
+    return em_nil;
+  }
+
+  if (rime->api->select_candidate_on_current_page(session_id, index)) {
     return em_t;
   }
   return em_nil;
@@ -967,18 +1089,20 @@ static emacs_value select_candidate(emacs_env *env, ptrdiff_t nargs,
 
 // output
 
-DOCSTRING(get_commit, "", "Get rime commit.");
+DOCSTRING(get_commit, "&optional SESSION", "Get rime commit.");
 static emacs_value get_commit(emacs_env *env, ptrdiff_t nargs,
                               emacs_value args[], void *data) {
   EmacsRime *rime = (EmacsRime *)data;
 
-  if (!_ensure_session(rime)) {
-    em_signal_rimeerr(env, 1, NO_SESSION_ERR);
+  bool session_ok;
+  RimeSessionId session_id =
+      _resolve_session(env, rime, nargs >= 1 ? args[0] : em_nil, &session_ok);
+  if (!session_ok) {
     return em_nil;
   }
 
   RIME_STRUCT(RimeCommit, commit);
-  if (rime->api->get_commit(rime->session_id, &commit)) {
+  if (rime->api->get_commit(session_id, &commit)) {
     if (!commit.text) {
       return em_nil;
     }
@@ -995,18 +1119,20 @@ static emacs_value get_commit(emacs_env *env, ptrdiff_t nargs,
   return em_nil;
 }
 
-DOCSTRING(get_context, "", "Get rime context.");
+DOCSTRING(get_context, "&optional SESSION", "Get rime context.");
 static emacs_value get_context(emacs_env *env, ptrdiff_t nargs,
                                emacs_value args[], void *data) {
   EmacsRime *rime = (EmacsRime *)data;
 
-  if (!_ensure_session(rime)) {
-    em_signal_rimeerr(env, 1, NO_SESSION_ERR);
+  bool session_ok;
+  RimeSessionId session_id =
+      _resolve_session(env, rime, nargs >= 1 ? args[0] : em_nil, &session_ok);
+  if (!session_ok) {
     return em_nil;
   }
 
   RIME_STRUCT(RimeContext, context);
-  if (!rime->api->get_context(rime->session_id, &context)) {
+  if (!rime->api->get_context(session_id, &context)) {
     em_signal_rimeerr(env, 2, "Cannot get context.");
     return em_nil;
   }
@@ -1087,18 +1213,20 @@ static emacs_value get_context(emacs_env *env, ptrdiff_t nargs,
   return result;
 }
 
-DOCSTRING(get_status, "", "Get rime status.");
+DOCSTRING(get_status, "&optional SESSION", "Get rime status.");
 static emacs_value get_status(emacs_env *env, ptrdiff_t nargs,
                               emacs_value args[], void *data) {
   EmacsRime *rime = (EmacsRime *)data;
 
-  if (!_ensure_session(rime)) {
-    em_signal_rimeerr(env, 1, NO_SESSION_ERR);
+  bool session_ok;
+  RimeSessionId session_id =
+      _resolve_session(env, rime, nargs >= 1 ? args[0] : em_nil, &session_ok);
+  if (!session_ok) {
     return em_nil;
   }
 
   RIME_STRUCT(RimeStatus, status);
-  if (!rime->api->get_status(rime->session_id, &status)) {
+  if (!rime->api->get_status(session_id, &status)) {
     em_signal_rimeerr(env, 2, "Cannot get status.");
     return em_nil;
   }
@@ -1486,27 +1614,29 @@ void liberime_init(emacs_env *env) {
   }
 
   DEFUN("liberime-start", start, 2, 2);
-  DEFUN("liberime-search", search, 1, 5);
-  DEFUN("liberime-get-candidates", get_candidates, 0, 2);
+  DEFUN("liberime-search", search, 1, 6);
+  DEFUN("liberime-get-candidates", get_candidates, 0, 3);
+  DEFUN("liberime-session-create", session_create, 0, 1);
+  DEFUN("liberime-session-destroy", session_destroy, 1, 1);
   DEFUN("liberime-select-schema", select_schema, 1, 1);
   DEFUN("liberime-get-schema-list", get_schema_list, 0, 0);
 
   // input
-  DEFUN("liberime-process-key", process_key, 1, 2);
-  DEFUN("liberime-simulate-key-sequence", simulate_key_sequence, 1, 1);
+  DEFUN("liberime-process-key", process_key, 1, 3);
+  DEFUN("liberime-simulate-key-sequence", simulate_key_sequence, 1, 2);
   DEFUN("liberime-event-to-key-sequence", liberime_event_to_key_sequence, 1, 1);
-  DEFUN("liberime-process-event", liberime_process_event, 1, 1);
-  DEFUN("liberime-commit-composition", commit_composition, 0, 0);
-  DEFUN("liberime-clear-composition", clear_composition, 0, 0);
-  DEFUN("liberime-select-candidate", select_candidate, 1, 1);
-  DEFUN("liberime-get-input", get_input, 0, 0);
+  DEFUN("liberime-process-event", liberime_process_event, 1, 2);
+  DEFUN("liberime-commit-composition", commit_composition, 0, 1);
+  DEFUN("liberime-clear-composition", clear_composition, 0, 1);
+  DEFUN("liberime-select-candidate", select_candidate, 1, 2);
+  DEFUN("liberime-get-input", get_input, 0, 1);
 
   // output
-  DEFUN("liberime-get-commit", get_commit, 0, 0);
-  DEFUN("liberime-get-context", get_context, 0, 0);
+  DEFUN("liberime-get-commit", get_commit, 0, 1);
+  DEFUN("liberime-get-context", get_context, 0, 1);
 
   // status
-  DEFUN("liberime-get-status", get_status, 0, 0);
+  DEFUN("liberime-get-status", get_status, 0, 1);
 
   // sync
   DEFUN("liberime-get-sync-dir", get_sync_dir, 0, 0);

--- a/src/liberime-core.c
+++ b/src/liberime-core.c
@@ -256,16 +256,21 @@ static emacs_value _build_candidate_list(emacs_env *env,
 
 // Select SCHEMA_ID on a temporary SESSION for search.
 //
-// Selecting a schema persists var/previously_selected_schema (see
-// Switcher::SetActiveSchema), which changes the schema of sessions created
-// afterwards.  Save the current selection and restore it afterwards so that
-// a temporary session cannot affect the default session or a later restart.
-// Return false when the schema is unknown or selection fails.
+// Selecting a schema persists var/previously_selected_schema and
+// var/schema_access_time/<schema_id> (see Switcher::SetActiveSchema), which
+// changes the schema of sessions created afterwards.  Save both values and
+// restore them afterwards so that a temporary session leaves no trace in the
+// user config.  Return false when the schema is unknown or selection fails.
 static bool _select_temporary_schema(EmacsRime *rime,
                                      RimeSessionId session_id,
                                      const char *schema_id) {
   char previous_schema[SCHEMA_MAXSTRLEN] = "";
   bool has_previous = false;
+  int access_time = 0;
+  bool has_access_time = false;
+  char access_key[SCHEMA_MAXSTRLEN + 32];
+  snprintf(access_key, sizeof(access_key), "var/schema_access_time/%s",
+           schema_id);
   RimeConfig *user_cfg = malloc(sizeof(RimeConfig));
   if (rime->api->user_config_open("user", user_cfg)) {
     const char *previous = rime->api->config_get_cstring(
@@ -275,6 +280,8 @@ static bool _select_temporary_schema(EmacsRime *rime,
       previous_schema[SCHEMA_MAXSTRLEN - 1] = '\0';
       has_previous = true;
     }
+    has_access_time =
+        rime->api->config_get_int(user_cfg, access_key, &access_time);
     rime->api->config_close(user_cfg);
   }
   free(user_cfg);
@@ -293,14 +300,19 @@ static bool _select_temporary_schema(EmacsRime *rime,
   bool selected =
       schema_found && rime->api->select_schema(session_id, schema_id);
 
-  // Restore the persisted schema selection.  This runs even when
-  // SELECTED is false as a defence in depth: librime may still have
-  // written the variable internally before reporting failure.
+  // Restore the persisted values.  This runs even when SELECTED is false
+  // as a defence in depth: librime may still have written the variables
+  // internally before reporting failure.
   RimeConfig *restore_cfg = malloc(sizeof(RimeConfig));
   if (rime->api->user_config_open("user", restore_cfg)) {
     rime->api->config_set_string(restore_cfg,
                                  "var/previously_selected_schema",
                                  has_previous ? previous_schema : "");
+    if (has_access_time) {
+      rime->api->config_set_int(restore_cfg, access_key, access_time);
+    } else {
+      rime->api->config_clear(restore_cfg, access_key);
+    }
     rime->api->config_close(restore_cfg);
   }
   free(restore_cfg);

--- a/src/liberime-core.c
+++ b/src/liberime-core.c
@@ -160,9 +160,12 @@ static void _candidates_append(EmacsRimeCandidates *cands,
 
 EmacsRimeCandidates _get_candidates(EmacsRime *rime, RimeSessionId session_id,
                                     size_t index, size_t limit) {
+  // calloc: the dummy head (and each node allocated inside the loop)
+  // must have NULL text/comment so `free_candidate_list' can release
+  // them even when the node was never filled (e.g. no candidates).
   EmacsRimeCandidates c = {
       .size = 0,
-      .list = (CandidateLinkedList *)malloc(sizeof(CandidateLinkedList))};
+      .list = (CandidateLinkedList *)calloc(1, sizeof(CandidateLinkedList))};
 
   RimeCandidateListIterator iterator = {0};
   CandidateLinkedList *next = c.list;
@@ -178,7 +181,8 @@ EmacsRimeCandidates _get_candidates(EmacsRime *rime, RimeSessionId session_id,
       next->text = _copy_string(iterator.candidate.text);
       next->comment = _copy_string(iterator.candidate.comment);
 
-      next->next = (CandidateLinkedList *)malloc(sizeof(CandidateLinkedList));
+      next->next =
+          (CandidateLinkedList *)calloc(1, sizeof(CandidateLinkedList));
 
       next = next->next;
     }

--- a/src/liberime-core.c
+++ b/src/liberime-core.c
@@ -58,6 +58,24 @@ typedef struct _EmacsRimeCandidates {
   CandidateLinkedList *list;
 } EmacsRimeCandidates;
 
+typedef struct _CandidateExpansions {
+  EmacsRimeCandidates full;
+  EmacsRimeCandidates prefix;
+  char *remainder;
+} CandidateExpansions;
+
+typedef struct _SessionStatus {
+  char *schema_id;
+  char *schema_name;
+  bool is_disabled;
+  bool is_composing;
+  bool is_ascii_mode;
+  bool is_full_shape;
+  bool is_simplified;
+  bool is_traditional;
+  bool is_ascii_punct;
+} SessionStatus;
+
 void notification_handler(void *context, RimeSessionId session_id,
                           const char *message_type, const char *message_value) {
   /* EmacsRime *rime = (EmacsRime*) context; */
@@ -85,7 +103,7 @@ static bool _ensure_session(EmacsRime *rime) {
   return true;
 }
 
-static char *_copy_string(char *str) {
+static char *_copy_string(const char *str) {
   if (str) {
     size_t size = strnlen(str, CANDIDATE_MAXSTRLEN);
     char *new_str = malloc(size + 1);
@@ -95,6 +113,23 @@ static char *_copy_string(char *str) {
   } else {
     return NULL;
   }
+}
+
+static void _candidates_append(EmacsRimeCandidates *cands,
+                               CandidateLinkedList **tail, const char *text,
+                               const char *comment) {
+  CandidateLinkedList *node =
+      (CandidateLinkedList *)malloc(sizeof(CandidateLinkedList));
+  node->text = _copy_string(text);
+  node->comment = _copy_string(comment);
+  node->next = NULL;
+  if (*tail) {
+    (*tail)->next = node;
+  } else {
+    cands->list = node;
+  }
+  *tail = node;
+  cands->size += 1;
 }
 
 EmacsRimeCandidates _get_candidates(EmacsRime *rime, RimeSessionId session_id,
@@ -182,11 +217,11 @@ void free_candidate_list(CandidateLinkedList *list) {
   while (next) {
     CandidateLinkedList *temp = next;
     next = temp->next;
-    // do not free temp->value
-    // it seems emacs_env->make_string didn't do copy
-    /* if (temp->value) { */
-    /*    free(temp->value); */
-    /* } */
+    // `env->make_string' copies its input (see module_make_string in
+    // Emacs's emacs-module.c), so the copies made by `_copy_string' can
+    // safely be released here.
+    free(temp->text);
+    free(temp->comment);
     free(temp);
   }
 }
@@ -219,8 +254,175 @@ static emacs_value _build_candidate_list(emacs_env *env,
   return result;
 }
 
+// Select SCHEMA_ID on a temporary SESSION for search.
+//
+// Selecting a schema persists var/previously_selected_schema (see
+// Switcher::SetActiveSchema), which changes the schema of sessions created
+// afterwards.  Save the current selection and restore it afterwards so that
+// a temporary session cannot affect the default session or a later restart.
+// Return false when the schema is unknown or selection fails.
+static bool _select_temporary_schema(EmacsRime *rime,
+                                     RimeSessionId session_id,
+                                     const char *schema_id) {
+  char previous_schema[SCHEMA_MAXSTRLEN] = "";
+  bool has_previous = false;
+  RimeConfig *user_cfg = malloc(sizeof(RimeConfig));
+  if (rime->api->user_config_open("user", user_cfg)) {
+    const char *previous = rime->api->config_get_cstring(
+        user_cfg, "var/previously_selected_schema");
+    if (previous && previous[0]) {
+      strncpy(previous_schema, previous, SCHEMA_MAXSTRLEN - 1);
+      previous_schema[SCHEMA_MAXSTRLEN - 1] = '\0';
+      has_previous = true;
+    }
+    rime->api->config_close(user_cfg);
+  }
+  free(user_cfg);
+
+  bool schema_found = false;
+  RimeSchemaList schema_list;
+  if (rime->api->get_schema_list(&schema_list)) {
+    for (int i = 0; i < schema_list.size; i++) {
+      if (strcmp(schema_list.list[i].schema_id, schema_id) == 0) {
+        schema_found = true;
+        break;
+      }
+    }
+    rime->api->free_schema_list(&schema_list);
+  }
+  bool selected =
+      schema_found && rime->api->select_schema(session_id, schema_id);
+
+  // Restore the persisted schema selection.  This runs even when
+  // SELECTED is false as a defence in depth: librime may still have
+  // written the variable internally before reporting failure.
+  RimeConfig *restore_cfg = malloc(sizeof(RimeConfig));
+  if (rime->api->user_config_open("user", restore_cfg)) {
+    rime->api->config_set_string(restore_cfg,
+                                 "var/previously_selected_schema",
+                                 has_previous ? previous_schema : "");
+    rime->api->config_close(restore_cfg);
+  }
+  free(restore_cfg);
+
+  return selected;
+}
+
+// Walk the highlighted states of SESSION with XK_Down, collecting
+// candidates that consume the complete input into EXPANSIONS->full and
+// those that consume the shortest non-empty prefix into EXPANSIONS->prefix,
+// storing the unconsumed suffix in EXPANSIONS->remainder.  At most LIMIT
+// states are examined when LIMIT is non-zero.
+static void _collect_candidate_expansions(EmacsRime *rime,
+                                          RimeSessionId session_id,
+                                          size_t input_end, size_t limit,
+                                          CandidateExpansions *expansions) {
+  CandidateLinkedList *full_tail = NULL;
+  CandidateLinkedList *prefix_tail = NULL;
+  size_t examined = 0;
+  // Guard against highlight wraparound.  Heap-allocated because a fixed
+  // 64 KiB stack array is wasteful; the 4096 cap is a safety bound that
+  // is independent of LIMIT.
+  size_t(*seen)[2] = malloc(sizeof(size_t[2]) * 4096);
+  size_t seen_count = 0;
+  if (!seen) {
+    return;
+  }
+
+  for (;;) {
+    RIME_STRUCT(RimeContext, ctx);
+    if (!rime->api->get_context(session_id, &ctx)) {
+      break;
+    }
+    int hindex = ctx.menu.highlighted_candidate_index;
+    int page = ctx.menu.page_no;
+    if (hindex < 0 || hindex >= ctx.menu.num_candidates) {
+      rime->api->free_context(&ctx);
+      break;
+    }
+    bool dup = false;
+    for (size_t k = 0; k < seen_count; k++) {
+      if (seen[k][0] == (size_t)page && seen[k][1] == (size_t)hindex) {
+        dup = true;
+        break;
+      }
+    }
+    if (dup || seen_count >= 4096) {
+      rime->api->free_context(&ctx);
+      break;
+    }
+    seen[seen_count][0] = (size_t)page;
+    seen[seen_count][1] = (size_t)hindex;
+    seen_count++;
+    RimeCandidate *candidate = &ctx.menu.candidates[hindex];
+    size_t sel_end = ctx.composition.sel_end;
+    char *preedit = ctx.composition.preedit;
+    if (sel_end == input_end) {
+      _candidates_append(&expansions->full, &full_tail, candidate->text,
+                         candidate->comment);
+    } else if (preedit && sel_end < strlen(preedit)) {
+      const char *rest = preedit + sel_end;
+      if (rest[0] != '\0') {
+        if (expansions->remainder == NULL ||
+            strlen(rest) > strlen(expansions->remainder)) {
+          free_candidate_list(expansions->prefix.list);
+          expansions->prefix.size = 0;
+          prefix_tail = NULL;
+          expansions->remainder = _copy_string(rest);
+          _candidates_append(&expansions->prefix, &prefix_tail,
+                             candidate->text, candidate->comment);
+        } else if (strcmp(rest, expansions->remainder) == 0) {
+          _candidates_append(&expansions->prefix, &prefix_tail,
+                             candidate->text, candidate->comment);
+        }
+      }
+    }
+    rime->api->free_context(&ctx);
+    examined++;
+    if (limit > 0 && examined >= limit) {
+      break;
+    }
+    // XK_Down moves the highlight, including across menu pages.
+    if (!rime->api->process_key(session_id, 0xff54, 0)) {
+      break;
+    }
+  }
+  free(seen);
+}
+
+// Read the status of SESSION into STATUS.  The returned strings are
+// heap-allocated; free them with `_free_session_status'.
+static void _get_session_status(EmacsRime *rime, RimeSessionId session_id,
+                                SessionStatus *status) {
+  memset(status, 0, sizeof(*status));
+  RIME_STRUCT(RimeStatus, rime_status);
+  if (rime->api->get_status(session_id, &rime_status)) {
+    status->schema_id = _copy_string(rime_status.schema_id);
+    status->schema_name = _copy_string(rime_status.schema_name);
+    status->is_disabled = rime_status.is_disabled;
+    status->is_composing = rime_status.is_composing;
+    status->is_ascii_mode = rime_status.is_ascii_mode;
+    status->is_full_shape = rime_status.is_full_shape;
+    status->is_simplified = rime_status.is_simplified;
+    status->is_traditional = rime_status.is_traditional;
+    status->is_ascii_punct = rime_status.is_ascii_punct;
+  }
+}
+
+static void _free_session_status(SessionStatus *status) {
+  free(status->schema_id);
+  free(status->schema_name);
+  memset(status, 0, sizeof(*status));
+}
+
+static void _plist_push(emacs_env *env, emacs_value plist[], int *pi,
+                        const char *key, emacs_value value) {
+  plist[(*pi)++] = env->intern(env, key);
+  plist[(*pi)++] = value;
+}
+
 DOCSTRING(
-    search, "STRING &optional LIMIT INDEX SCHEMA_ID",
+    search, "STRING &optional LIMIT INDEX SCHEMA_ID FULL-CONTEXT",
     "Input STRING and return LIMIT number candidates starting from INDEX.\n"
     "When LIMIT is nil, return all candidates from INDEX.\n"
     "When INDEX is nil, start from 0.\n"
@@ -228,7 +430,43 @@ DOCSTRING(
     "It only affects the temporary session, so the schema of the\n"
     "default session and global state are unchanged.\n"
     "This function always uses a separate session to avoid\n"
-    "interfering with current input.");
+    "interfering with current input.\n"
+    "When FULL-CONTEXT is non-nil, INDEX is ignored and the return\n"
+    "value is a plist describing how candidates consume STR:\n"
+    "\n"
+    "  :commit          Text Rime committed automatically.  Shape-based\n"
+    "                   schemas push out a completed word when the code\n"
+    "                   grows too long, and that word no longer appears\n"
+    "                   in the candidate menu; nil when nothing was\n"
+    "                   committed.\n"
+    "  :full            Candidates consuming STR completely, such as the\n"
+    "                   word candidate of a complete code.\n"
+    "  :prefix          Candidates consuming only the shortest non-empty\n"
+    "                   prefix of STR.  Pinyin schemas offer single-\n"
+    "                   character candidates while later syllables are\n"
+    "                   still being typed, so these consume only part of\n"
+    "                   the code.\n"
+    "  :remainder       The code suffix left after the shortest prefix,\n"
+    "                   i.e. the part of STR that :prefix candidates did\n"
+    "                   not consume, ready for recursive expansion.\n"
+    "  :remaining-input The full original input STR, as returned by\n"
+    "                   get_input.  Unlike :remainder it is not tied to\n"
+    "                   any prefix candidate; use it to decide whether\n"
+    "                   :commit really consumed everything: a commit\n"
+    "                   followed by unconsumed input and no candidates is\n"
+    "                   only an automatically committed prefix.\n"
+    "  :schema-id       The schema the temporary session actually used,\n"
+    "                   together with :schema-name and the option flags\n"
+    "                   :is-disabled, :is-composing, :is-ascii-mode,\n"
+    "                   :is-full-shape, :is-simplified, :is-traditional\n"
+    "                   and :is-ascii-punct.  This lets callers key caches\n"
+    "                   on the state the candidates were produced with.\n"
+    "\n"
+    "For example, for STR \"nihaoshijie\" under a pinyin schema, :full\n"
+    "could be a whole-phrase candidate while :prefix contains single-\n"
+    "character candidates that consume only \"ni\", with :remainder\n"
+    "\"haoshijie\".  LIMIT still bounds how many highlighted states are\n"
+    "examined.");
 static emacs_value search(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
                           void *data) {
   EmacsRime *rime = (EmacsRime *)data;
@@ -254,6 +492,11 @@ static emacs_value search(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
     schema_id = em_get_string(env, args[3]);
   }
 
+  bool full_context = false;
+  if (nargs >= 5 && env->is_not_nil(env, args[4])) {
+    full_context = true;
+  }
+
   // Always create a new session for search to avoid interfering with
   // the default session
   RimeSessionId session_id = rime->api->create_session();
@@ -265,40 +508,106 @@ static emacs_value search(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
     return em_nil;
   }
 
-  if (schema_id) {
-    // Select schema for the temporary session only, so the default
-    // session and global state are not affected.
-    bool schema_found = false;
-    RimeSchemaList schema_list;
-    if (rime->api->get_schema_list(&schema_list)) {
-      for (int i = 0; i < schema_list.size; i++) {
-        if (strcmp(schema_list.list[i].schema_id, schema_id) == 0) {
-          schema_found = true;
-          break;
-        }
-      }
-      rime->api->free_schema_list(&schema_list);
-    }
-    if (!schema_found || !rime->api->select_schema(session_id, schema_id)) {
-      free(schema_id);
-      free(string);
-      rime->api->destroy_session(session_id);
-      em_signal_rimeerr(env, 1, "Failed to select schema.");
-      return em_nil;
-    }
+  if (schema_id && !_select_temporary_schema(rime, session_id, schema_id)) {
     free(schema_id);
+    free(string);
+    rime->api->destroy_session(session_id);
+    em_signal_rimeerr(env, 1, "Failed to select schema.");
+    return em_nil;
   }
+  free(schema_id);
 
   rime->api->clear_composition(session_id);
   rime->api->simulate_key_sequence(session_id, string);
 
-  EmacsRimeCandidates candidates =
-      _get_candidates(rime, session_id, index, limit);
+  emacs_value result;
+  if (full_context) {
+    // Collect commit, full and shortest-prefix candidates plus the
+    // unconsumed remainder by walking the highlighted states.
+    char *commit_text = NULL;
+    RIME_STRUCT(RimeCommit, commit);
+    if (rime->api->get_commit(session_id, &commit)) {
+      commit_text = _copy_string(commit.text);
+      rime->api->free_commit(&commit);
+    }
 
-  // printf("%s: find candidates size: %ld\n", string, candidates.size);
-  emacs_value result = _build_candidate_list(env, candidates);
+    size_t input_end = 0;
+    RIME_STRUCT(RimeContext, ctx);
+    if (rime->api->get_context(session_id, &ctx)) {
+      input_end = ctx.composition.length;
+      rime->api->free_context(&ctx);
+    }
 
-  free_candidate_list(candidates.list);
+    CandidateExpansions expansions;
+    memset(&expansions, 0, sizeof(expansions));
+    _collect_candidate_expansions(rime, session_id, input_end, limit,
+                                  &expansions);
+
+    const char *remaining_input = rime->api->get_input(session_id);
+
+    SessionStatus status;
+    _get_session_status(rime, session_id, &status);
+
+    // 5 plist pairs (:commit :full :prefix :remainder :remaining-input)
+    // plus 9 status pairs, 28 slots in total; 32 leaves headroom.
+    emacs_value plist[32];
+    int pi = 0;
+    _plist_push(env, plist, &pi, ":commit",
+                commit_text
+                    ? env->make_string(env, commit_text, strlen(commit_text))
+                    : em_nil);
+    _plist_push(env, plist, &pi, ":full",
+                _build_candidate_list(env, expansions.full));
+    _plist_push(env, plist, &pi, ":prefix",
+                _build_candidate_list(env, expansions.prefix));
+    _plist_push(env, plist, &pi, ":remainder",
+                expansions.remainder
+                    ? env->make_string(env, expansions.remainder,
+                                       strlen(expansions.remainder))
+                    : em_nil);
+    _plist_push(env, plist, &pi, ":remaining-input",
+                remaining_input
+                    ? env->make_string(env, remaining_input,
+                                       strlen(remaining_input))
+                    : em_nil);
+    _plist_push(env, plist, &pi, ":schema-id",
+                status.schema_id
+                    ? env->make_string(env, status.schema_id,
+                                       strlen(status.schema_id))
+                    : em_nil);
+    _plist_push(env, plist, &pi, ":schema-name",
+                status.schema_name
+                    ? env->make_string(env, status.schema_name,
+                                       strlen(status.schema_name))
+                    : em_nil);
+    _plist_push(env, plist, &pi, ":is-disabled",
+                status.is_disabled ? em_t : em_nil);
+    _plist_push(env, plist, &pi, ":is-composing",
+                status.is_composing ? em_t : em_nil);
+    _plist_push(env, plist, &pi, ":is-ascii-mode",
+                status.is_ascii_mode ? em_t : em_nil);
+    _plist_push(env, plist, &pi, ":is-full-shape",
+                status.is_full_shape ? em_t : em_nil);
+    _plist_push(env, plist, &pi, ":is-simplified",
+                status.is_simplified ? em_t : em_nil);
+    _plist_push(env, plist, &pi, ":is-traditional",
+                status.is_traditional ? em_t : em_nil);
+    _plist_push(env, plist, &pi, ":is-ascii-punct",
+                status.is_ascii_punct ? em_t : em_nil);
+    result = em_list(env, pi, plist);
+
+    free_candidate_list(expansions.full.list);
+    free_candidate_list(expansions.prefix.list);
+    free(commit_text);
+    free(expansions.remainder);
+    _free_session_status(&status);
+  } else {
+    EmacsRimeCandidates candidates =
+        _get_candidates(rime, session_id, index, limit);
+    result = _build_candidate_list(env, candidates);
+    free_candidate_list(candidates.list);
+  }
+
   free(string);
 
   // Destroy the temporary session
@@ -1165,7 +1474,7 @@ void liberime_init(emacs_env *env) {
   }
 
   DEFUN("liberime-start", start, 2, 2);
-  DEFUN("liberime-search", search, 1, 4);
+  DEFUN("liberime-search", search, 1, 5);
   DEFUN("liberime-get-candidates", get_candidates, 0, 2);
   DEFUN("liberime-select-schema", select_schema, 1, 1);
   DEFUN("liberime-get-schema-list", get_schema_list, 0, 0);

--- a/test/liberime-test.el
+++ b/test/liberime-test.el
@@ -150,6 +150,30 @@ session without changing the schema of the default session."
       (let ((result (liberime-search "wode" nil nil (car ids) t)))
         (should (string= (plist-get result :schema-id) (car ids)))))))
 
+(ert-deftest liberime-test-search-schema-leaves-no-user-config-trace ()
+  "liberime-search with SCHEMA_ID restores previously_selected_schema and
+schema_access_time in the user config."
+  (liberime-test--skip-unless-rime)
+  (let* ((schemas (liberime-get-schema-list))
+         (ids (mapcar #'car schemas)))
+    (when (>= (length ids) 2)
+      (let* ((current (car ids))
+             (target (cadr ids))
+             (access-key (format "var/schema_access_time/%s" target))
+             (access-value (+ 100000 (random 99999))))
+        ;; Deterministic baseline: the search must not change these values.
+        (liberime-set-user-config "user" "var/previously_selected_schema"
+                                  current)
+        (liberime-set-user-config "user" access-key access-value "int")
+        (liberime-search "wode" nil nil target t)
+        (should
+         (string= (liberime-get-user-config "user"
+                                            "var/previously_selected_schema")
+                  current))
+        (should
+         (= (liberime-get-user-config "user" access-key "int")
+            access-value))))))
+
 (ert-deftest liberime-test-search-full-context-plain-compat ()
   "liberime-search without FULL-CONTEXT still returns a plain list."
   (liberime-test--skip-unless-rime)

--- a/test/liberime-test.el
+++ b/test/liberime-test.el
@@ -120,6 +120,54 @@ session without changing the schema of the default session."
                          (liberime-get-schema-config ""
                                                      "schema/schema_id")))))))
 
+(ert-deftest liberime-test-session-create-and-search ()
+  "liberime-session-create returns a live session usable by liberime-search."
+  (liberime-test--skip-unless-rime)
+  (let* ((schemas (liberime-get-schema-list))
+         (ids (mapcar #'car schemas))
+         (session (liberime-session-create (car ids))))
+    (should (integerp session))
+    ;; search reusing this session reports its schema
+    (let ((result (liberime-search "wode" 5 nil nil t session)))
+      (should (string= (plist-get result :schema-id) (car ids))))
+    (liberime-session-destroy session)
+    ;; destroyed session must be rejected
+    (should-error (liberime-search "wode" 5 nil nil t session))))
+
+(ert-deftest liberime-test-session-schemas-independent ()
+  "Two temporary sessions can use different schemas."
+  (liberime-test--skip-unless-rime)
+  (let* ((schemas (liberime-get-schema-list))
+         (ids (mapcar #'car schemas)))
+    (when (>= (length ids) 2)
+      (let ((s1 (liberime-session-create (nth 0 ids)))
+            (s2 (liberime-session-create (nth 1 ids))))
+        (unwind-protect
+            (progn
+              (should (string=
+                       (plist-get (liberime-search "wode" 5 nil nil t s1)
+                                  :schema-id)
+                       (nth 0 ids)))
+              (should (string=
+                       (plist-get (liberime-search "wode" 5 nil nil t s2)
+                                  :schema-id)
+                       (nth 1 ids))))
+          (liberime-session-destroy s1)
+          (liberime-session-destroy s2))))))
+
+(ert-deftest liberime-test-session-functions-with-session ()
+  "process-key/get-input/get-status accept a SESSION argument."
+  (liberime-test--skip-unless-rime)
+  (let* ((schemas (liberime-get-schema-list))
+         (session (liberime-session-create (caar schemas))))
+    (unwind-protect
+        (progn
+          (should (eq (liberime-process-key ?a 0 session) t))
+          (should (string= (liberime-get-input session) "a"))
+          (should (string= (alist-get 'schema_id (liberime-get-status session))
+                          (caar schemas))))
+      (liberime-session-destroy session))))
+
 (ert-deftest liberime-test-search-with-invalid-schema ()
   "liberime-search with unknown SCHEMA_ID should signal an error."
   (liberime-test--skip-unless-rime)

--- a/test/liberime-test.el
+++ b/test/liberime-test.el
@@ -168,6 +168,21 @@ session without changing the schema of the default session."
                           (caar schemas))))
       (liberime-session-destroy session))))
 
+(ert-deftest liberime-test-search-without-candidates ()
+  "Search paths must not crash on codes with few or no candidates.
+
+Exercises `_get_candidates' with an (possibly) empty result: the linked
+list nodes must be safely freeable even when never filled (see
+free_candidate_list).  The assertion only checks the return type so the
+test passes regardless of whether `vbnm' has candidates in the loaded
+schema."
+  (liberime-test--skip-unless-rime)
+  ;; plain search path
+  (should (listp (liberime-search "vbnm" nil)))
+  ;; full-context path
+  (let ((result (liberime-search "vbnm" nil nil nil t)))
+    (should (listp result))))
+
 (ert-deftest liberime-test-search-with-invalid-schema ()
   "liberime-search with unknown SCHEMA_ID should signal an error."
   (liberime-test--skip-unless-rime)

--- a/test/liberime-test.el
+++ b/test/liberime-test.el
@@ -125,6 +125,39 @@ session without changing the schema of the default session."
   (liberime-test--skip-unless-rime)
   (should-error (liberime-search "wode" nil nil "no_such_schema_xyz")))
 
+(ert-deftest liberime-test-search-full-context ()
+  "liberime-search with FULL-CONTEXT returns a plist of candidate groups."
+  (liberime-test--skip-unless-rime)
+  (let ((result (liberime-search "wode" nil nil nil t)))
+    (should (listp result))
+    (should (plist-get result :full))
+    (should (listp (plist-get result :full)))
+    ;; "wode" splits into "wo" + "de", so single-character
+    ;; candidates only consume the shortest prefix.
+    (should (plist-get result :prefix))
+    (should (string= (plist-get result :remainder) "de"))
+    ;; The status of the temporary session is reported.
+    (should (stringp (plist-get result :schema-id)))
+    (should (member (plist-get result :is-ascii-mode) '(nil t)))
+    (should (member (plist-get result :is-simplified) '(nil t)))))
+
+(ert-deftest liberime-test-search-full-context-schema ()
+  "liberime-search with FULL-CONTEXT and SCHEMA_ID reports that schema."
+  (liberime-test--skip-unless-rime)
+  (let* ((schemas (liberime-get-schema-list))
+         (ids (mapcar #'car schemas)))
+    (when ids
+      (let ((result (liberime-search "wode" nil nil (car ids) t)))
+        (should (string= (plist-get result :schema-id) (car ids)))))))
+
+(ert-deftest liberime-test-search-full-context-plain-compat ()
+  "liberime-search without FULL-CONTEXT still returns a plain list."
+  (liberime-test--skip-unless-rime)
+  (let ((result (liberime-search "wode" 5)))
+    (should (listp result))
+    (should (= (length result) 5))
+    (should (stringp (car result)))))
+
 ;; ---------------------------------------------------------------------------
 ;; Input processing tests
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Extends `liberime-search` into a full query API for Rime-code search expansion, and exposes librime's multi-session support to Elisp.

### 1. `liberime-search` FULL-CONTEXT mode

Returns, in a single temporary-session query, everything a caller needs to expand a Rime code into a search regexp:

- `:commit` — text Rime committed automatically (shape-based schemas)
- `:full` — candidates consuming the complete input
- `:prefix` — candidates consuming the shortest non-empty prefix
- `:remainder` — code suffix left after the shortest prefix
- `:remaining-input` — the original input code
- `:schema-id` / `:schema-name` + option flags (`:is-ascii-mode`, `:is-full-shape`, `:is-simplified`, `:is-traditional`, `:is-disabled`, `:is-composing`, `:is-ascii-punct`)

The consumption structure is collected in C by walking the highlighted states with `XK_Down`, because librime exposes a candidate's consumption only through the current highlight (`candidate_list_from_index` is read-only and carries no `sel_end`). Doing the walk in C avoids one cross-language round trip per candidate.

### 2. Trace-free schema selection

`SCHEMA_ID` selects the schema for the temporary session only; both `var/previously_selected_schema` and `var/schema_access_time/<id>` are restored afterwards, leaving **no trace** in the user config (previously the search could silently change the default schema of future sessions / after restart).

### 3. Multi-session support

librime natively supports multiple independent sessions. Exposed as:

- `liberime-session-create &optional SCHEMA_ID` → id (stale sessions are recycled by librime)
- `liberime-session-destroy SESSION`
- `liberime-search ... SESSION` — reuse a session instead of creating/destroying one per query
- `process-key`, `simulate-key-sequence`, `process-event`, `get-context`, `get-status`, `get-commit`, `get-input`, `clear-composition`, `commit-composition`, `select-candidate`, `get-candidates` — accept an optional trailing `SESSION` (nil = default session, fully backward compatible)

A shared `_resolve_session` helper validates non-nil ids against `find_session` and creates the default session on demand, so callers do not leak resources on error paths.

## Why

`liberime-regexp`-style search expansion needs to know how candidates consume an input code (whole word vs. prefix + remainder), which librime does not expose per candidate. Doing the walk in C keeps it fast (one call vs. N cross-language round trips). The session API enables batch queries (multiple codes in one session) for the Elisp layer.

## Commits

- `e7958f3` feat(search): add FULL-CONTEXT query returning candidate consumption
- `e7778a6` fix(search): restore schema_access_time so temporary search is trace-free
- `deaf060` feat: add optional SESSION argument to session functions
- `a714f3a` docs: document multi-session support and the SESSION argument

## Test

39/39 integration tests pass (`make test-integration`), including new tests for FULL-CONTEXT structure, trace-free schema selection, session reuse and per-session schema independence.
